### PR TITLE
Don't update shared objects on prefixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-monitor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Brian Stack <bstack@mozilla.com>",
   "description": "Make it easy to hook up monitoring and metrics for taskcluster services.",
   "license": "MPL-2.0",

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -14,11 +14,11 @@ class Monitor {
     this._sentry = sentry; // This must be a Promise that resolves to {client, expires}
     this._statsum = statsumClient;
 
-    if (opts.reportStatsumErrors) {
+    if (!opts.isPrefixed && opts.reportStatsumErrors) {
       this._statsum.on('error', err => this.reportError(err, 'warning'));
     }
 
-    if (opts.patchGlobal) {
+    if (!opts.isPrefixed && opts.patchGlobal) {
       process.on('uncaughtException', (err) => {
         console.log(err.stack);
         this.reportError(err);
@@ -68,11 +68,13 @@ class Monitor {
   }
 
   prefix (prefix) {
+    let newopts = _.cloneDeep(this._opts);
+    newopts.isPrefixed = true;
     return new Monitor(
       this._auth,
       this._sentry,
       this._statsum.prefix(prefix),
-      _.cloneDeep(this._opts)
+      newopts
     );
   }
 }
@@ -134,6 +136,7 @@ async function monitor (options) {
   let opts = _.defaults(options, {
     patchGlobal: true,
     reportStatsumErrors: true,
+    isPrefixed: false,
   });
 
   if (options.mock) {


### PR DESCRIPTION
This would do unnecessary work on prefixing and break because of a way statsum client is implemented.
