### PR TITLE
Add basic timers for standard tc needs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-monitor",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "Brian Stack <bstack@mozilla.com>",
   "description": "Make it easy to hook up monitoring and metrics for taskcluster services.",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "promise": "^7.0.4",
     "raven": "^0.10.0",
     "statsum": "^0.4.1",
-    "taskcluster-client": "^0.23.16"
+    "taskcluster-client": "^0.23.16",
+    "usage": "^0.7.1"
   },
   "devDependencies": {
     "babel-compile": "^2.0.0",

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -182,7 +182,7 @@ class MockMonitor {
   }
 
   timedHandler (name, handler) {
-    return async (message) => { };
+    return async (message) => { await handler(message); };
   }
 
   expressMiddleware (name) {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -181,6 +181,16 @@ class MockMonitor {
     this.measures[k] = (this.measures[k] || []).concat(val);
   }
 
+  timedHandler (name, handler) {
+    return async (message) => { };
+  }
+
+  expressMiddleware (name) {
+    return (req, res, next) => {
+      next();
+    };
+  }
+
   _key (key) {
     let p = '.';
     if (this._opts.prefix) {


### PR DESCRIPTION
This adds utility functions to:
1. Time express endpoints and report to statsum
2. Time generic handlers and report to statsum

It also sets up resource usage monitoring on a minute-by-minute basis.
