### PR TITLE
Only deploy this package from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
 language: node_js
 sudo: false
 node_js:
-  - '0.12'
-  - '4'
-  - '5'
-  - '6'
+- '0.12'
+- '4'
+- '5'
+- '6'
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+    - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+    - g++-4.8
 script: npm test
 env:
   global:
-    - DEBUG='taskcluster-lib-monitor test'
-    - CXX=g++-4.8
-
+  - DEBUG='taskcluster-lib-monitor test'
+  - CXX=g++-4.8
 notifications:
   irc:
     channels:
-      # encrpyted string was "irc.mozilla.org#taskcluster-bots"
-      - secure: "Jr+3ft8ZZknJ0Zr1xKwCNEgqMyrFwkMkfJEJo7q8cHvGvRK3iw+GDGj10wjSk8Juf19MkFsICkldHdQEZfCrjAuOhINmqe4mLfkn+RJo/UgVk8K1BcniJdegnZn7laYTpj9Sjs0MySqUJps+UWVIe6kq4dB4Yjrl/2zyLbcwUkQPaYpnfWAm6KoQXuim7Qrsn0isQRj577TzSj2x5IUJ66F8ZbubP8CDIo1RBkfB9ZIeAjrJf5FL7U+/+rZketOVjqDOptrriTJ/eytd14LI5Iw9oZKdX3SXXsPmz3+alG5xb2Jy7lzU96mV6OYD723VQkSnpLQJ+UORfJJhYkXNupfLveFhMiIMWeybGghxUd2s5vZ7prXlC/ldx4fDMkCuEVcXkr7icqvzhEFOYqn+khsrDiQmFNLmOxocyxhG7KtzhUEr+m1XRTqZ+kE5YRG/DGJJNN4kt6+z3+ytLhyXNX0wwV035dUN8UhrKk8+2pE6OvlpaaaD+pb46Q+GT2prloC6j4w5A4I5wQwBByerihb4clO5vOlBtZamgsn5dqSW74ERuZi44hguFQUGBE3wWYdtHYqJo/gX0z+F1wXXWKlozQdkmaVT9z2oiRMgtN/vs8qG4/13M1LVqkmogzNZKBfMuh5BoQkhKOtzeA6+ioHNUfer6DrLxJzT3AALCCs="
+    - secure: Jr+3ft8ZZknJ0Zr1xKwCNEgqMyrFwkMkfJEJo7q8cHvGvRK3iw+GDGj10wjSk8Juf19MkFsICkldHdQEZfCrjAuOhINmqe4mLfkn+RJo/UgVk8K1BcniJdegnZn7laYTpj9Sjs0MySqUJps+UWVIe6kq4dB4Yjrl/2zyLbcwUkQPaYpnfWAm6KoQXuim7Qrsn0isQRj577TzSj2x5IUJ66F8ZbubP8CDIo1RBkfB9ZIeAjrJf5FL7U+/+rZketOVjqDOptrriTJ/eytd14LI5Iw9oZKdX3SXXsPmz3+alG5xb2Jy7lzU96mV6OYD723VQkSnpLQJ+UORfJJhYkXNupfLveFhMiIMWeybGghxUd2s5vZ7prXlC/ldx4fDMkCuEVcXkr7icqvzhEFOYqn+khsrDiQmFNLmOxocyxhG7KtzhUEr+m1XRTqZ+kE5YRG/DGJJNN4kt6+z3+ytLhyXNX0wwV035dUN8UhrKk8+2pE6OvlpaaaD+pb46Q+GT2prloC6j4w5A4I5wQwBByerihb4clO5vOlBtZamgsn5dqSW74ERuZi44hguFQUGBE3wWYdtHYqJo/gX0z+F1wXXWKlozQdkmaVT9z2oiRMgtN/vs8qG4/13M1LVqkmogzNZKBfMuh5BoQkhKOtzeA6+ioHNUfer6DrLxJzT3AALCCs=
     on_success: change
     on_failure: always
     template:
@@ -29,3 +27,11 @@ notifications:
     - 'Change view : %{compare_url}'
     - 'Build details : %{build_url}'
     - 'Commit message : %{commit_message}'
+deploy:
+  provider: npm
+  email: taskcluster-accounts@mozilla.com
+  api_key:
+    secure: OowWlp/O7mx4bL5rxVIdCubwTHxrAFSR+l7ozbior5pfnRpdsqkaNq7m9J3+nr8bhjwlG+yD5GFemMLfq+BO188CMabyLH8kw2CrOGdBYtJDSWCf5SFQv3eKksN/WM8WXRm8Q/ghHf/YAlueSuLXiGj8/eMOxFBsFB+VIdJx7vAi6cm0+OJi9K4Qq5eApxGIlGHC128YNet3QnuPFU7bgjHD6is4pTMaCdObBN0WSVNYe8v4OTjL1KAIB3R14rp/TaGnYgebg2tvMJFq+mlOfMugl5cJq2RaOpmSbA15B/p52TDFWIIVIpo0hua+QAdS7fJPsFYVybFLFnFb9hTJakR8JumnRkVzbfsu6s8f5JWVCUNg7/BjPqtKyVKtWeoLq1LISSRQcSWlxQ+K5sKxF5ca9iP+rOyT60RG7nJAbcQ3hTRSbiQU7SHFeF8gfqeart04GN3zksqaH5kEsdoHM04ROMGrr2joDteL675QdzAqliB27wEua7ZQM7ysgOGiVKcCRKA/1Ar/oEMsDmoCzYEY71VHC+WAMJcjoYvUrmGWuf/6NXpro8+Hn36dEAyZ5azaE4QydphmZxFtMEfVICFOHdWEeMh9z/TewKvDN8psBDmwkhtJg64uWHyxzUanj/pFn+SGZglKi+z6kd6qJlhLt9NarW271Uf7slqzzrw=
+  on:
+    tags: true
+    repo: taskcluster/taskcluster-lib-monitor

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
   },
   "devDependencies": {
     "babel-compile": "^2.0.0",
-    "babel-preset-taskcluster": "^2.3.0",
     "babel-eslint": "^6.0.0",
+    "babel-preset-taskcluster": "^2.3.0",
+    "eslint-config-taskcluster": "^2.0.0",
+    "eslint-plugin-taskcluster": "^1.0.0",
     "mocha": "2.5.3",
     "mocha-eslint": "^2.0.1",
     "mock-aws-s3": "^2.1.0",
     "nock": "^8.0.0",
     "source-map-support": "^0.4.0",
-    "taskcluster-lib-testing": "^1.0.0",
-    "eslint-config-taskcluster": "^2.0.0",
-    "eslint-plugin-taskcluster": "^1.0.0"
+    "taskcluster-lib-testing": "^1.0.0"
   },
   "main": "./lib/monitor.js"
 }

--- a/test/package_test.js
+++ b/test/package_test.js
@@ -1,0 +1,15 @@
+suite('Package', () => {
+  let assert = require('assert');
+  let pack = require('../package.json');
+  let exec = require('child_process');
+
+  test('git tag must match package version', function() {
+    let tag = exec.execSync('git tag -l --contains HEAD').toString().trim();
+    if (tag === '') {
+      console.log('    No git tag, no need to check tag!');
+      this.skip();
+    }
+    assert.equal('v' + pack.version, tag);
+  });
+
+});


### PR DESCRIPTION
@djmitche, @eliperelman: You both might also be interested.

This is just the result of running `travis setup npm` in this repo and adding in account details for the new taskcluster-bot user on npm. You can find the api key to use if you'd like to set this up for your own projects at https://www.npmjs.com/settings/tokens and you can login to get to that page using creds shared in lastpass. @jonasfj has created a bots team in the npm organization and I've moved this project under that team with read/write and turned it into read-only for the developers team. This _should_ prevent us from deploying to this any other way. We can see how this goes for a while and roll it out to the rest of our libraries if it works?

https://docs.travis-ci.com/user/deployment/npm/ has more info on how this should work.

_note: this whole thing will work best if you use the `npm version` command to version your packages._
