### PR TITLE
Ensure we either report or crash fatal errors

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -17,7 +17,7 @@ class Monitor {
     this._resourceInterval = null;
   }
 
-  async reportError(err, level='error', tags={}, listen=false) {
+  async reportError(err, level='error', tags={}, _listen=false) {
     if (!_.isString(level)) {
       tags = level;
       level = 'error';
@@ -43,7 +43,7 @@ class Monitor {
       });
 
       return new Promise((accept, reject) => {
-        if (!listen) {
+        if (!_listen) {
           // In the standard case, we have to reason to wait
           // for this to complete. Generally we'll avoid adding
           // listeners all over the place and so just accept()
@@ -68,8 +68,8 @@ class Monitor {
 
   // captureError is an alias for reportError to match up
   // with the raven api better.
-  async captureError(err, level='error', tags={}, listen=false) {
-    this.reportError(err, level, tags, listen);
+  async captureError(err, level='error', tags={}, _listen=false) {
+    this.reportError(err, level, tags, _listen);
   }
 
   count(key, val) {
@@ -126,12 +126,12 @@ class MockMonitor {
     this._resourceInterval = null;
   }
 
-  async reportError(err, level='error', tags={}, listen=false) {
+  async reportError(err, level='error', tags={}, _listen=false) {
     this.errors.push(err);
   }
 
-  async captureError(err, level='error', tags={}, listen=false) {
-    this.reportError(err, level, tags, listen);
+  async captureError(err, level='error', tags={}, _listen=false) {
+    this.reportError(err, level, tags, _listen);
   }
 
   count(key, val) {

--- a/test/should_exit_with_error.js
+++ b/test/should_exit_with_error.js
@@ -1,0 +1,31 @@
+// This test needs to take place in an external function that we
+// fork to avoid issues with uncaught exceptions and mocha and
+// our process.exit behavior.
+let monitoring = require('../');
+let authmock = require('./authmock');
+let nock = require('nock');
+
+function nockit(delay) {
+  nock('https://app.getsentry.com')
+    .filteringRequestBody(/.*/, '*')
+    .post('/api/12345/store/', '*')
+    .delay(delay)
+    .reply(200, () => {
+      console.log('Called Sentry.');
+    });
+}
+
+if (process.argv[2] === '--correct') {
+  nockit(0);
+} else {
+  nockit(10000);
+}
+
+authmock.setup();
+monitoring({
+  project: 'tc-lib-monitor',
+  credentials: {clientId: 'test-client', accessToken: 'test'},
+  crashTimeout: 250,
+}).then((monitor) => {
+  process.nextTick(() => { throw new Error('This should bubble up to the top'); });
+});

--- a/test/statsum_test.js
+++ b/test/statsum_test.js
@@ -27,9 +27,6 @@ suite('Statsum', () => {
       patchGlobal: false,
       reportStatsumErrors: false,
     });
-    setTimeout(function() {
-      sentryNock.done();
-    }, 2000);
   });
 
   teardown(async () => {

--- a/test/uncaught_test.js
+++ b/test/uncaught_test.js
@@ -1,0 +1,124 @@
+suite('Uncaught Errors', () => {
+  let assert = require('assert');
+  let monitoring = require('../');
+  let debug = require('debug')('test');
+  let nock = require('nock');
+  let authmock = require('./authmock');
+  let path = require('path');
+  let fork = require('child_process').fork;
+  let _ = require('lodash');
+
+  let monitor = null;
+
+  suiteSetup(async () => {
+    authmock.setup();
+
+    monitor = await monitoring({
+      project: 'tc-lib-monitor',
+      credentials: {clientId: 'test-client', accessToken: 'test'},
+    });
+  });
+
+  suiteTeardown(() => {
+    authmock.teardown();
+  });
+
+  test('should report unhandled rejections', async function(done) {
+
+    let sentryScope = nock('https://app.getsentry.com')
+      .filteringRequestBody(/.*/, '*')
+      .post('/api/12345/store/', '*')
+      .reply(200, () => {
+        debug('called Sentry.');
+        done();
+      });
+
+    setTimeout(function() {
+      sentryScope.done();
+    }, 2000);
+
+    throw new Error('This should hopefully bubble up to the top!');
+  });
+
+  // These tests needs to take place in an external function that we
+  // fork to avoid issues with uncaught exceptions and mocha and
+  // our process.exit behavior.
+
+  test('should report uncaught exceptions', async function(done) {
+
+    let proc = fork(
+      path.resolve(__dirname, './should_exit_with_error.js'),
+      ['--correct'],
+      {
+        env: process.env,
+        silent: true,
+      }
+    );
+
+    let output = '';
+
+    proc.stdout.on('data', function(data) {
+      output += data.toString();
+    });
+
+    proc.stderr.on('data', function(data) {
+      output += data.toString();
+    });
+
+    proc.on('exit', function(code) {
+      try {
+        assert(_.startsWith(output,
+          [
+            'Uncaught Exception! Attempting to report to Sentry and crash.',
+            'Error: This should bubble up to the top',
+          ].join('\n')
+        ));
+        assert(_.endsWith(output, 'Called Sentry.\nSuccesfully reported error to Sentry.\n'));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  test('should exit no matter what', async function(done) {
+
+    let proc = fork(
+      path.resolve(__dirname, './should_exit_with_error.js'),
+      ['--incorrect'],
+      {
+        env: process.env,
+        silent: true,
+      }
+    );
+
+    let output = '';
+
+    proc.stdout.on('data', function(data) {
+      let s = data.toString();
+      debug(s);
+      output += s;
+    });
+
+    proc.stderr.on('data', function(data) {
+      let s = data.toString();
+      debug(s);
+      output += s;
+    });
+
+    proc.on('exit', function(code) {
+      try {
+        assert(_.startsWith(output,
+          [
+            'Uncaught Exception! Attempting to report to Sentry and crash.',
+            'Error: This should bubble up to the top',
+          ].join('\n')
+        ));
+        assert(_.endsWith(output, 'Failed to report error to Sentry after timeout!\n'));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This should ensure that we report fatal errors and crash. It may fail to report the error but at least it will crash!

Upon writing this, I've realized the reason that dependencyResolver isn't crashing! It's because the 'error' we're reporting is turned into an unreseolved promise rather than an uncaught error and we don't crash on unresolved promises! We should throw the error inside a `process.nextTick()` or  find some other way to deal with this if we want to crash on these errors.
