### PR TITLE
Don't raise error when we can't log to sentry

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -41,7 +41,7 @@ class Monitor {
         console.log('Can\'t report to sentry, error not reported: ', err.stack);
         return Promise.resolve();
       }
-      
+
       sentry.client.captureException(err, {
         tags: _.defaults({
           prefix: this._opts.project + (this._opts.prefix || '.root'),
@@ -54,11 +54,12 @@ class Monitor {
         let onLogged, onError;
         onLogged = () => {
           sentry.client.removeListener('error', onError);
-          accept();
+          accept(true);
         };
         onError = (e) => {
           sentry.client.removeListener('logged', onLogged);
-          reject(new Error('Failed to log error to Sentry: ' + e));
+          console.log('Failed to log error to Sentry: ' + e);
+          accept(false);
         };
         sentry.client.once('logged', onLogged);
         sentry.client.once('error', onError);
@@ -69,7 +70,7 @@ class Monitor {
   // captureError is an alias for reportError to match up
   // with the raven api better.
   async captureError(err, level='error', tags={}) {
-    this.reportError(err, level, tags);
+    return this.reportError(err, level, tags);
   }
 
   count(key, val) {
@@ -133,10 +134,11 @@ class MockMonitor {
 
   async reportError(err, level='error', tags={}) {
     this.errors.push(err);
+    return true;
   }
 
   async captureError(err, level='error', tags={}) {
-    this.reportError(err, level, tags);
+    return this.reportError(err, level, tags);
   }
 
   count(key, val) {

--- a/test/sentry_failure_test.js
+++ b/test/sentry_failure_test.js
@@ -1,4 +1,4 @@
-suite('Sentry', () => {
+suite('Sentry Failure', () => {
   let assert = require('assert');
   let monitoring = require('../');
   let debug = require('debug')('test');
@@ -26,26 +26,15 @@ suite('Sentry', () => {
     let sentryScope = nock('https://app.getsentry.com')
       .filteringRequestBody(/.*/, '*')
       .post('/api/12345/store/', '*')
-      .twice()
-      .reply(200, () => {
-        debug('called Sentry.');
-      })
-      .post('/api/12345/store/', '*')
-      .reply(200, () => {
-        debug('called Sentry the correct amount of times.');
-        done();
+      .reply(500, () => {
+        debug('called Sentry, returned 500');
       });
 
     setTimeout(function() {
       sentryScope.done();
     }, 2000);
 
-    let results = await Promise.all([
-      monitor.reportError('create sentry error test'),
-      monitor.reportError('another time'),
-      monitor.captureError('this is the same as reportError'),
-    ]);
-    assert.deepEqual(results, [true, true, true]);
+    done(assert.equal(false, await monitor.reportError('stranger things')));
   });
 
 });


### PR DESCRIPTION
This should be a fix for https://app.getsentry.com/taskcluster/taskcluster-queue/issues/145571133/activity/
