### PR TITLE
also count aws-sdk operations

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -130,6 +130,7 @@ export function patchAWS(monitor, service) {
     r.on('complete', () => {
       let requestTime = (new Date()).getTime() - r.startTime.getTime();
       monitor.measure(operation + '.duration', requestTime);
+      monitor.count(operation + '.count', 1);
     });
     return r;
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -129,8 +129,13 @@ export function patchAWS(monitor, service) {
     let r = makeRequest.call(this, operation, params, callback);
     r.on('complete', () => {
       let requestTime = (new Date()).getTime() - r.startTime.getTime();
-      monitor.measure(operation + '.duration', requestTime);
-      monitor.count(operation + '.count', 1);
+      monitor.measure(`global.${operation}.duration`, requestTime);
+      monitor.count(`global.${operation}.count`, 1);
+      if (service.config && service.config.region) {
+        let region = service.config.region;
+        monitor.measure(`${region}.${operation}.duration`, requestTime);
+        monitor.count(`${region}.${operation}.count`, 1);
+      }
     });
     return r;
   };

--- a/test/mockmonitor_test.js
+++ b/test/mockmonitor_test.js
@@ -140,7 +140,13 @@ suite('MockMonitor', () => {
     await ec2.describeAvailabilityZones().promise().catch(err => {
       debug('Ignored ec2 error, we measure duration, not success, err: ', err);
     });
-    let data = monitor.measures['mm.ec2.describeAvailabilityZones.duration'];
+    let data = monitor.measures['mm.ec2.global.describeAvailabilityZones.duration'];
     assert(data.length === 1);
+    data = monitor.measures['mm.ec2.us-west-2.describeAvailabilityZones.duration'];
+    assert(data.length === 1);
+    data = monitor.counts['mm.ec2.global.describeAvailabilityZones.count'];
+    assert(data === 1);
+    data = monitor.counts['mm.ec2.us-west-2.describeAvailabilityZones.count'];
+    assert(data === 1);
   });
 });


### PR DESCRIPTION
Can we also count these operations?  Almost more than the duration right now, what I need is the count.  I'm also going to probably ask for more things to add.  Not sure how this should impact semver...
