### PR TITLE
Fix .taskcluster.yml that was just tabbed over one to few spaces

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,22 +7,22 @@ metadata:
 
 tasks:
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-  workerType: "{{ taskcluster.docker.workerType }}"
-  extra:
-    github:
-      env: true
-      events:
-        - pull_request.opened
-        - pull_request.synchronize
-        - pull_request.reopened
-        - push
-  payload:
-    maxRunTime: 3600
-    image: "node:5"
-    command:
-      - "/bin/bash"
-      - "-lc"
-      - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && npm install . && npm test"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
+          - push
+    payload:
+      maxRunTime: 3600
+      image: "node:5"
+      command:
+        - "/bin/bash"
+        - "-lc"
+        - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && npm install . && npm test"
     metadata:
       name: "taskcluster-lib-monitor test"
       description: "tests for metrics and monitoring library"


### PR DESCRIPTION
@owlishDeveloper, hey, this pretty much worked, but once I merged it, we got an error:

```
Sep 19 17:54:11 taskcluster-github app/worker.1: Unhandled Rejection at: Promise [object Object] reason: YAMLException: bad indentation of a mapping entry at line 10, column 3: 
Sep 19 17:54:11 taskcluster-github app/worker.1:       workerType: "{{ taskcluster.dock ...  
Sep 19 17:54:11 taskcluster-github app/worker.1:       ^ 
```

I just fixed it and submitted this for review from you! No problem at all that it didn't work on the first try. The docs are confusing right now. In fact, if you noticed anything awry during this process, maybe make a PR into taskcluster-docs on this file https://github.com/taskcluster/taskcluster-docs/blob/master/src/manual/vcs/github.md to improve the docs! Perhaps change the `quay.io/mrrrgn` link to the right one and the command as well. Also a note about being extra careful about spacing in the `.taskclyuster.yml` would be nice I think? Making taskcluster notify us when things go wrong with parsing this file is one of the goals for the next outreachy project!

In the mean time, if you review this and think it's good to merge, I'll do it first thing in the morning!
