### PR TITLE
Upgrade raven to avoid node-uuid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "debug": "^2.2.0",
     "lodash": "^4.5.1",
     "promise": "^7.0.4",
-    "raven": "^0.11.0",
+    "raven": "^1.1.1",
     "statsum": "^0.5.1",
     "taskcluster-client": "^1.0.1",
     "usage": "^0.7.1"


### PR DESCRIPTION
How do we run sentry tests here? Is that automatic or do we need to run locally and look in sentry to ensure that it sends errors...

Maybe review, I suspect there might be something...
https://github.com/getsentry/raven-node/blob/master/History.md

Consider this PR more of a bug report than a fix...