### PR TITLE
Fix monitor.timer

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -105,17 +105,18 @@ export function resources(monitor, proc, seconds) {
 
 export function timer(monitor, prefix, funcOrPromise) {
   let start = process.hrtime();
-  let done = () => {
+  let done = (x) => {
     let d = process.hrtime(start);
     monitor.measure(prefix, d[0] * 1000 + d[1] / 1000000);
   };
   if (funcOrPromise instanceof Function) {
     try {
       funcOrPromise = funcOrPromise();
-    } finally {
+    } catch(e) {
       // If this is a sync function that throws, we let it...
       // We just remember to call done() afterwards
       done();
+      throw e;
     }
   }
   Promise.resolve(funcOrPromise).then(done, done);

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,7 @@ export function timer(monitor, prefix, funcOrPromise) {
   if (funcOrPromise instanceof Function) {
     try {
       funcOrPromise = funcOrPromise();
-    } catch(e) {
+    } catch (e) {
       // If this is a sync function that throws, we let it...
       // We just remember to call done() afterwards
       done();

--- a/test/mockmonitor_test.js
+++ b/test/mockmonitor_test.js
@@ -83,6 +83,7 @@ suite('MockMonitor', () => {
   test('monitor.timer(k, () => value)', async () => {
     let v = monitor.timer('k', () => 45);
     assert(v == 45);
+    await new Promise(accept => setTimeout(accept, 10));
     assert(monitor.measures['mm.k'].length === 1);
   });
 
@@ -92,6 +93,7 @@ suite('MockMonitor', () => {
       return 45;
     });
     assert(v == 45);
+    await new Promise(accept => setTimeout(accept, 10));
     assert(monitor.measures['mm.k'].length === 1);
   });
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,0 +1,71 @@
+const utils = require('../lib/utils.js');
+const assert = require('assert');
+
+suite('utils', function() {
+  suite('timer', function() {
+    let monitor;
+
+    setup(function() {
+      monitor = {
+        measure: (prefix, ms) => monitor.measures.push({prefix, ms}),
+        measures: [],
+      };
+    });
+
+    const takes100ms = () => new Promise(resolve => setTimeout(() => resolve(13), 100));
+    const checkMonitor = (len) => {
+      // check this after a short delay, as otherwise the Promise.resolve
+      // can measure something after timer returns..
+      return new Promise(resolve => setTimeout(resolve, 10)).then(() => {
+        assert.equal(monitor.measures.length, len);
+        monitor.measures.forEach(m => assert.equal(m.prefix, 'pfx'));
+      });
+    };
+
+    test('of a sync function', async function() {
+      assert.equal(utils.timer(monitor, 'pfx', () => 13), 13);
+      await checkMonitor(1);
+    });
+
+    test('of a sync function that fails', async function() {
+      assert.throws(() => {
+        utils.timer(monitor, 'pfx', () => { throw new Error('uhoh'); });
+      }, /uhoh/);
+      await checkMonitor(1);
+    });
+
+    test('of an async function', async function() {
+      assert.equal(await utils.timer(monitor, 'pfx', takes100ms), 13);
+      await checkMonitor(1);
+      assert(monitor.measures[0].ms >= 90);
+    });
+
+    test('of an async function that fails', async function() {
+      let err;
+      try {
+        await utils.timer(monitor, 'pfx', async () => { throw new Error('uhoh'); });
+      } catch (e) {
+        err = e;
+      }
+      assert(err && /uhoh/.test(err.message));
+      await checkMonitor(1);
+    });
+
+    test('of a promise', async function() {
+      assert.equal(await utils.timer(monitor, 'pfx', takes100ms()), 13);
+      await checkMonitor(1);
+      assert(monitor.measures[0].ms >= 90);
+    });
+
+    test('of a failed promise', async function() {
+      let err;
+      try {
+        await utils.timer(monitor, 'pfx', Promise.reject(new Error('uhoh')));
+      } catch (e) {
+        err = e;
+      }
+      assert(err && /uhoh/.test(err.message));
+      await checkMonitor(1);
+    });
+  });
+});


### PR DESCRIPTION
The existing implementation would measure everything twice, once in the
finally block (which, for async functions and promises, occurred almost
immediately) and once in the promise completion.