### PR TITLE
Debug-log more stuff in mocked errors

### DIFF
--- a/src/mockmonitor.js
+++ b/src/mockmonitor.js
@@ -14,7 +14,7 @@ class MockMonitor {
   }
 
   async reportError(err, level='error', tags={}) {
-    debug('reportError: %j', err);
+    debug('reportError: %s level=%s tags=%j', err, level, tags, err && err.stack);
     this.errors.push(err);
     return true;
   }


### PR DESCRIPTION
Otherwise I get "reportError: {}" in the debug logs, which isn't so
helpful!