### PR TITLE
Bug 1452611 - pass sentryOptions to constructor, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The available options are:
     usage of the process will be reported on an interval. Note: This can also be
     turned on by monitor.resources(...) later if wanted.  That allows for
     gracefully stopping as well.
+ * `statsumToken` - a function that will return a Statsum token (`async (project) => {token, expires, baseUrl}`); the default value uses `credentials` to fetch a token from the Auth service.
+ * `sentryDSN` - a function that will return a Sentry DSN (`async (project) => {dsn: {secret: '...'}, expires}`); the default value uses `credentials` to fetch a DSN from the Auth service.
+ * `sentryOptions`:options given to the [raven.Client constructor](https://docs.sentry.io/clients/node/config/)
  * `mock` - If true, the monitoring object will be a fake that stores data for testing but does not report it (for testing).
  * `enable` - If false, the monitoring object will only report to the console (but not store data; for deployments without monitoring)
  * `aws` - If provided, these should be of the form `{credentials: {accessKeyId: '...', secretAccessKey: '...'}, region: '...'}`

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,11 @@ let path = require('path');
  *   },
  *   // If credentials aren't given, you must supply:
  *   statsumToken: async (project) => {token, expires, baseUrl}
- *   sentryDNS: async (project) => {dsn: {secret: '...'}, expires}
+ *
+ *   sentryDSN: async (project) => {dsn: {secret: '...'}, expires}
+ *   sentryOptions: {}, // options given to raven.Client constructor
+ *   // see https://docs.sentry.io/clients/node/config/
+ *
  *   // If you'd like to use the logging bits, you'll need to provide
  *   // s3 creds directly for now
  *   aws: {credentials: {accessKeyId, secretAccessKey}},
@@ -49,6 +53,7 @@ async function monitor(options) {
     enable: true,
     logName: null,
     aws: null,
+    sentryOptions: {},
     gitVersionFile: '.git-version',
   });
   assert(options.authBaseUrl || options.credentials || options.statsumToken && options.sentryDSN ||

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -31,9 +31,10 @@ class Monitor {
       if (!sentry.expires || Date.parse(sentry.expires) <= Date.now()) {
         let sentryInfo = await this._sentryDSN(this._opts.project);
         return {
-          client: new raven.Client(sentryInfo.dsn.secret, {
-            release: this._opts.gitVersion,
-          }),
+          client: new raven.Client(sentryInfo.dsn.secret, _.defaults(
+            {}, this._opts.sentryOptions, {
+              release: this._opts.gitVersion,
+            })),
           expires: sentryInfo.expires,
         };
       }


### PR DESCRIPTION
I'd like to use this to make a fingerprint method that will combine all
of these annoying queue SSL errors into a single record in Sentry.  But
I think it might be useful in general.

Sorry, I just can't quit PR'ing this repo :)