### PR TITLE
Swap out Firehose support for Kinesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The available options are:
  * `mock` - If true, the monitoring object will be a fake that stores data for testing but does not report it (for testing).
  * `enable` - If false, the monitoring object will only report to the console (but not store data; for deployments without monitoring)
  * `aws` - If provided, these should be of the form `{credentials: {accessKeyId: '...', secretAccessKey: '...'}, region: '...'}`
- * `logName` - If provided, this should be the name of a AWS Firehose deliveryStream that can be written to with the aws creds
+ * `logName` - If provided, this should be the name of a AWS Kinesis stream that can be written to with the aws creds
  * `gitVersion` -  git version (for correlating errors); or..
  * `gitVersionFile` -  file containing git version (relative to app root)
 
@@ -240,7 +240,7 @@ doodad.measure();
 
 ###  Audit Logs
 For the time being, this is restricted to services that have use AWS credentials directly rather than via accessing via the
-auth service. Given a set of credentials that allow writing to a Kinesis Firehose and the name of that Firehose, this will
+auth service. Given a set of credentials that allow writing to a Kinesis stream and the name of that Kinesis stream, this will
 allow writing arbitrary JSON blobs to that endpoint. The blobs will end up in S3 for permanent storage. We use this for things
 like audit logs that we want to keep for a long time. Records must be less than 1MB when stringified.
 

--- a/src/auditlogs.js
+++ b/src/auditlogs.js
@@ -99,10 +99,12 @@ class KinesisLog extends events.EventEmitter {
       let {records} = chunk;
       let res;
       try {
-        res = await this._kinesis.putRecord({
+        let krecords = records.map(line => {
+          return {Data: line.line, PartitionKey: AUDITLOG_PARTITION_KEY};
+        });
+        res = await this._kinesis.putRecords({
           StreamName: this._logName,
-          PartitionKey: AUDITLOG_PARTITION_KEY,
-          Data: records.map(line => line.line).join(''),
+          Records: krecords,
         }).promise();
       } catch (err) {
         if (!err.statusCode) {

--- a/src/auditlogs.js
+++ b/src/auditlogs.js
@@ -5,13 +5,17 @@ let Promise = require('bluebird');
 let AWS = require('aws-sdk');
 let utils = require('./utils');
 
-// These numbers come from the Firehose docs.
+// This number comes from the Kinesis docs.
 const MAX_RECORD_SIZE = 1000 * 1000;
 
 // This is just a number I picked.
 const MAX_RETRIES = 5;
 
-class FirehoseLog extends events.EventEmitter {
+// Consistent partition key for all records. This can be changed later if the volume of audit
+// logs greatly increases.
+const AUDITLOG_PARTITION_KEY = 'auditlog';
+
+class KinesisLog extends events.EventEmitter {
 
   constructor({aws, logName, reportAuditLogErrors, resourceInterval, crashTimeout, statsum}) {
     super();
@@ -21,7 +25,7 @@ class FirehoseLog extends events.EventEmitter {
 
     this._flushInterval = resourceInterval * 1000;
     this._crashTimeout = crashTimeout;
-    this._firehose = new AWS.Firehose(aws);
+    this._kinesis = new AWS.Kinesis(aws);
     this._logName = logName;
     this._records = [];
     this._flushTimer = setTimeout(this.flush.bind(this), this._flushInterval);
@@ -30,11 +34,11 @@ class FirehoseLog extends events.EventEmitter {
   }
 
   async setup() {
-    let stat = await this._firehose.describeDeliveryStream({
-      DeliveryStreamName: this._logName,
+    let stat = await this._kinesis.describeStream({
+      StreamName: this._logName,
     }).promise();
-    if (stat.DeliveryStreamDescription.DeliveryStreamStatus !== 'ACTIVE') {
-      throw new Error(`Delivery Stream ${this._logName} is not yet active!`);
+    if (stat.StreamDescription.StreamStatus !== 'ACTIVE') {
+      throw new Error(`Stream ${this._logName} is not yet active!`);
     }
   }
 
@@ -95,9 +99,10 @@ class FirehoseLog extends events.EventEmitter {
       let {records} = chunk;
       let res;
       try {
-        res = await this._firehose.putRecord({
-          DeliveryStreamName: this._logName,
-          Record: {Data: records.map(line => line.line).join('')},
+        res = await this._kinesis.putRecord({
+          StreamName: this._logName,
+          PartitionKey: AUDITLOG_PARTITION_KEY,
+          Data: records.map(line => line.line).join(''),
         }).promise();
       } catch (err) {
         if (!err.statusCode) {
@@ -146,4 +151,4 @@ class NoopLog extends events.EventEmitter {
   }
 }
 
-module.exports = {NoopLog, FirehoseLog};
+module.exports = {NoopLog, KinesisLog};

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ async function monitor(options) {
 
   let auditlog;
   if (options.enable && options.aws && options.logName) {
-    auditlog = new auditlogs.FirehoseLog(Object.assign({}, options, {statsum}));
+    auditlog = new auditlogs.KinesisLog(Object.assign({}, options, {statsum}));
   } else {
     auditlog = new auditlogs.NoopLog();
   }


### PR DESCRIPTION
Use Kinesis API in auditlog (through `KinesisLog`) instead of Firehose.

bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1488556

r? @imbstack 