### PR TITLE
Bug 1456909 - make oneShot a no-op in mock situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ with timing and error handling support.
 ```javascript
   'expire-info': {
     requires: ['cfg', 'monitor'],
-    setup: async ({cfg, monitor}) => {
-      monitor.oneShot('expire-info', () => {
+    setup: ({cfg, monitor}) => {
+      return monitor.oneShot('expire-info', () => {
         // do the expiration stuff
       });
     },  

--- a/src/base.js
+++ b/src/base.js
@@ -162,6 +162,7 @@ class BaseMonitor {
 
   /**
    * Monitor a one-shot process.  This function's promise never resolves!
+   * (except in testing, with MockMonitor)
    */
   async oneShot(name, fn) {
     let exitStatus = 0;

--- a/src/mockmonitor.js
+++ b/src/mockmonitor.js
@@ -60,6 +60,12 @@ class MockMonitor extends BaseMonitor {
     );
   }
 
+  /**
+   * Override oneShot to helpfully not call process.exit
+   */
+  async oneShot(name, fn) {
+    await fn();
+  }
 }
 
 module.exports = MockMonitor;

--- a/test/mockmonitor_test.js
+++ b/test/mockmonitor_test.js
@@ -153,4 +153,9 @@ suite('MockMonitor', () => {
     data = monitor.counts['mm.ec2.us-west-2.describeAvailabilityZones.count'];
     assert(data === 1);
   });
+
+  test('monitor.oneShot', async () => {
+    monitor.oneShot(() => {});
+    // just expect this not to call process.exit!
+  });
 });


### PR DESCRIPTION
This probably should have been included in https://github.com/taskcluster/taskcluster-lib-monitor/pull/75